### PR TITLE
Detect `$::` when accessing variable from different module

### DIFF
--- a/lib/puppet-lint/plugins/topscope_variable.rb
+++ b/lib/puppet-lint/plugins/topscope_variable.rb
@@ -3,9 +3,9 @@ PuppetLint.new_check(:topscope_variable) do
     class_list = (class_indexes + defined_type_indexes)
     # do not check if the code is not part of a class
     return if class_list.first.nil?
-    class_name = class_list.first[:name_token].value.split('::').first
+
     tokens.select { |x| x.type == :VARIABLE }.each do |token|
-      next if token.value !~ /^::#{class_name}::/
+      next if token.value !~ /^::[a-z0-9_][a-zA-Z0-9_]+::/
       fixed = token.value.sub(/^::/, '')
       notify(
         :warning,


### PR DESCRIPTION
In profile classes, it's quite common to access the variables from
component modules that you've just declared.

The code was originally written the way it was to make sure that facts
written as `$::fact_name` didn't get rewritten as `$fact_name` (which
according to the style guide is especially bad).  It was overly cautious
though. We can be certain that any variable with a second set of `::`
isn't a fact, so we don't need to limit the check to variables from our
module only.